### PR TITLE
Add improvements to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
                             <addClasspath>true</addClasspath>
                             <classpathPrefix>lib/</classpathPrefix>
                             <mainClass>net.draelcraft.draelcord.Draelcord</mainClass>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Adds `addDefaultImplementationEntries` and `addDefaultSpecifiactionEntries` (set to true) so that (e.g.) the artifact version can be accessed in a status command.